### PR TITLE
updated misleading artifact version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.deeplearning4j</groupId>
   <artifactId>deeplearning4j-examples</artifactId>
-  <version>0.0.3.3.3-SNAPSHOT</version>
+  <version>0.4-rc0-SNAPSHOT</version>
 
   <name>DeepLearning4j Examples</name>
   <description>Examples of training different data sets</description>


### PR DESCRIPTION
0.4-rc0-SNAPSHOT is better than 0.3.3.3-SNAPTHOT because this depends on
dl4j/nd4j 0.4-rc0.  Symmetric versioning saves users from confusion.