### PR TITLE
Fix non-termination on DBNMnistFullExample

### DIFF
--- a/src/main/java/org/deeplearning4j/examples/deepbelief/DBNMnistFullExample.java
+++ b/src/main/java/org/deeplearning4j/examples/deepbelief/DBNMnistFullExample.java
@@ -46,7 +46,7 @@ public class DBNMnistFullExample {
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                                            .seed(seed)
                                            .gradientNormalization(GradientNormalization.ClipElementWiseAbsoluteValue)
-                                           //.constrainGradientToUnitNorm(true)
+                                           .gradientNormalizationThreshold(1.0)
                                            .iterations(iterations)
                                            .momentum(0.5)
                                            .momentumAfter(Collections.singletonMap(3, 0.9))

--- a/src/main/java/org/deeplearning4j/examples/deepbelief/DBNMnistFullExample.java
+++ b/src/main/java/org/deeplearning4j/examples/deepbelief/DBNMnistFullExample.java
@@ -1,14 +1,12 @@
 package org.deeplearning4j.examples.deepbelief;
 
-
 import org.deeplearning4j.datasets.iterator.DataSetIterator;
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.deeplearning4j.eval.Evaluation;
 import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
-import org.deeplearning4j.nn.conf.Updater;
-import org.deeplearning4j.nn.conf.distribution.NormalDistribution;
+import org.deeplearning4j.nn.conf.GradientNormalization;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.conf.layers.RBM;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
@@ -46,32 +44,33 @@ public class DBNMnistFullExample {
 
         log.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
-                .seed(seed)
-                .constrainGradientToUnitNorm(true)
-                .iterations(iterations)
-                .momentum(0.5)
-                .momentumAfter(Collections.singletonMap(3, 0.9))
-                .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
-                .list(4)
-                .layer(0, new RBM.Builder().nIn(numRows*numColumns).nOut(500)
-                        .weightInit(WeightInit.XAVIER).lossFunction(LossFunction.RMSE_XENT)
-                        .visibleUnit(RBM.VisibleUnit.BINARY)
-                        .hiddenUnit(RBM.HiddenUnit.BINARY)
-                        .build())
-                .layer(1, new RBM.Builder().nIn(500).nOut(250)
-                        .weightInit(WeightInit.XAVIER).lossFunction(LossFunction.RMSE_XENT)
-                        .visibleUnit(RBM.VisibleUnit.BINARY)
-                        .hiddenUnit(RBM.HiddenUnit.BINARY)
-                        .build())
-                .layer(2, new RBM.Builder().nIn(250).nOut(200)
-                        .weightInit(WeightInit.XAVIER).lossFunction(LossFunction.RMSE_XENT)
-                        .visibleUnit(RBM.VisibleUnit.BINARY)
-                        .hiddenUnit(RBM.HiddenUnit.BINARY)
-                        .build())
-                .layer(3, new OutputLayer.Builder(LossFunction.NEGATIVELOGLIKELIHOOD).activation("softmax")
-                	.nIn(200).nOut(outputNum).build())
-		.pretrain(true).backprop(false)
-                .build();
+                                           .seed(seed)
+                                           .gradientNormalization(GradientNormalization.ClipElementWiseAbsoluteValue)
+                                           //.constrainGradientToUnitNorm(true)
+                                           .iterations(iterations)
+                                           .momentum(0.5)
+                                           .momentumAfter(Collections.singletonMap(3, 0.9))
+                                           .optimizationAlgo(OptimizationAlgorithm.CONJUGATE_GRADIENT)
+                                           .list(4)
+                                           .layer(0, new RBM.Builder().nIn(numRows*numColumns).nOut(500)
+                                                         .weightInit(WeightInit.XAVIER).lossFunction(LossFunction.RMSE_XENT)
+                                                         .visibleUnit(RBM.VisibleUnit.BINARY)
+                                                         .hiddenUnit(RBM.HiddenUnit.BINARY)
+                                                         .build())
+                                           .layer(1, new RBM.Builder().nIn(500).nOut(250)
+                                                         .weightInit(WeightInit.XAVIER).lossFunction(LossFunction.RMSE_XENT)
+                                                         .visibleUnit(RBM.VisibleUnit.BINARY)
+                                                         .hiddenUnit(RBM.HiddenUnit.BINARY)
+                                                         .build())
+                                           .layer(2, new RBM.Builder().nIn(250).nOut(200)
+                                                         .weightInit(WeightInit.XAVIER).lossFunction(LossFunction.RMSE_XENT)
+                                                         .visibleUnit(RBM.VisibleUnit.BINARY)
+                                                         .hiddenUnit(RBM.HiddenUnit.BINARY)
+                                                         .build())
+                                           .layer(3, new OutputLayer.Builder(LossFunction.NEGATIVELOGLIKELIHOOD).activation("softmax")
+                                                         .nIn(200).nOut(outputNum).build())
+                                           .pretrain(true).backprop(false)
+                                           .build();
 
         MultiLayerNetwork model = new MultiLayerNetwork(conf);
         model.init();


### PR DESCRIPTION
Removed the deprecated config option and replaced it with what (I believe) should provide equivalent functionality. I was able to run the model and have it terminate, though the performance is still dreadful.
Should fix #38 
