### PR TITLE
remove unused import to avoid depending on cpu backend explicitly

### DIFF
--- a/src/main/java/org/deeplearning4j/examples/paragraphvectors/tools/MeansBuilder.java
+++ b/src/main/java/org/deeplearning4j/examples/paragraphvectors/tools/MeansBuilder.java
@@ -1,16 +1,13 @@
 package org.deeplearning4j.examples.paragraphvectors.tools;
 
 import lombok.NonNull;
-import org.deeplearning4j.models.embeddings.WeightLookupTable;
 import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;
 import org.deeplearning4j.models.word2vec.VocabWord;
 import org.deeplearning4j.models.word2vec.wordstore.VocabCache;
 import org.deeplearning4j.text.documentiterator.LabelledDocument;
 import org.deeplearning4j.text.tokenization.tokenizerfactory.TokenizerFactory;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.cpu.NDArray;
 import org.nd4j.linalg.factory.Nd4j;
-
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 


### PR DESCRIPTION
This removes unused import `org.nd4j.linalg.cpu.NDArray`, which prohibits to switch backend from cpu to others.