### PR TITLE
squid:S1312 Loggers should be "private static final" and should share a naming convention

### DIFF
--- a/src/main/java/org/deeplearning4j/examples/autoencoder/StackedAutoEncoderMnistExample.java
+++ b/src/main/java/org/deeplearning4j/examples/autoencoder/StackedAutoEncoderMnistExample.java
@@ -28,7 +28,7 @@ import java.util.Collections;
  */
 public class StackedAutoEncoderMnistExample {
 
-    private static Logger log = LoggerFactory.getLogger(StackedAutoEncoderMnistExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(StackedAutoEncoderMnistExample.class);
 
     public static void main(String[] args) throws Exception {
         final int numRows = 28;
@@ -40,10 +40,10 @@ public class StackedAutoEncoderMnistExample {
         int seed = 123;
         int listenerFreq = batchSize / 5;
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator iter = new MnistDataSetIterator(batchSize,numSamples,true);
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
            .seed(seed)
            .gradientNormalization(GradientNormalization.ClipElementWiseAbsoluteValue)
@@ -75,10 +75,10 @@ public class StackedAutoEncoderMnistExample {
         model.init();
         model.setListeners(Arrays.asList((IterationListener) new ScoreIterationListener(listenerFreq)));
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         model.fit(iter); // achieves end to end pre-training
 
-        log.info("Evaluate model....");
+        LOG.info("Evaluate model....");
         Evaluation eval = new Evaluation(outputNum);
 
         DataSetIterator testIter = new MnistDataSetIterator(100,10000);
@@ -88,8 +88,8 @@ public class StackedAutoEncoderMnistExample {
             eval.eval(testMnist.getLabels(), predict2);
         }
 
-        log.info(eval.stats());
-        log.info("****************Example finished********************");
+        LOG.info(eval.stats());
+        LOG.info("****************Example finished********************");
 
     }
 

--- a/src/main/java/org/deeplearning4j/examples/convolution/CNNIrisExample.java
+++ b/src/main/java/org/deeplearning4j/examples/convolution/CNNIrisExample.java
@@ -31,7 +31,7 @@ import java.util.Random;
  */
 public class CNNIrisExample {
 
-    private static Logger log = LoggerFactory.getLogger(CNNIrisExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CNNIrisExample.class);
 
     public static void main(String[] args) {
 
@@ -48,7 +48,7 @@ public class CNNIrisExample {
         /**
          *Set a neural network configuration with multiple layers
          */
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator irisIter = new IrisDataSetIterator(150, 150);
         DataSet iris = irisIter.next();
         iris.normalizeZeroMeanZeroUnitVariance();
@@ -79,29 +79,29 @@ public class CNNIrisExample {
 
         MultiLayerConfiguration conf = builder.build();
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerNetwork model = new MultiLayerNetwork(conf);
         model.init();
         model.setListeners(Arrays.asList((IterationListener) new ScoreIterationListener(listenerFreq)));
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         System.out.println("Training on " + trainTest.getTrain().labelCounts());
         model.fit(trainTest.getTrain());
 
-        log.info("Evaluate weights....");
+        LOG.info("Evaluate weights....");
         for(org.deeplearning4j.nn.api.Layer layer : model.getLayers()) {
             INDArray w = layer.getParam(DefaultParamInitializer.WEIGHT_KEY);
-            log.info("Weights: " + w);
+            LOG.info("Weights: " + w);
         }
 
-        log.info("Evaluate model....");
+        LOG.info("Evaluate model....");
         System.out.println("Training on " + trainTest.getTest().labelCounts());
 
         Evaluation eval = new Evaluation(outputNum);
         INDArray output = model.output(trainTest.getTest().getFeatureMatrix());
         eval.eval(trainTest.getTest().getLabels(), output);
-        log.info(eval.stats());
+        LOG.info(eval.stats());
 
-        log.info("****************Example finished********************");
+        LOG.info("****************Example finished********************");
     }
 }

--- a/src/main/java/org/deeplearning4j/examples/convolution/CNNLFWExample.java
+++ b/src/main/java/org/deeplearning4j/examples/convolution/CNNLFWExample.java
@@ -50,7 +50,7 @@ import java.util.Random;
  */
 
 public class CNNLFWExample {
-    private static final Logger log = LoggerFactory.getLogger(CNNMnistExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CNNMnistExample.class);
 
     public static void main(String[] args) {
 
@@ -72,10 +72,10 @@ public class CNNLFWExample {
         List<INDArray> testInput = new ArrayList<>();
         List<INDArray> testLabels = new ArrayList<>();
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator lfw = new LFWDataSetIterator(batchSize, numSamples, new int[] {numRows, numColumns, nChannels}, outputNum, useSubset, new Random(seed));
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration.Builder builder = new NeuralNetConfiguration.Builder()
                 .seed(seed)
                 .iterations(iterations)
@@ -134,7 +134,7 @@ public class CNNLFWExample {
         MultiLayerNetwork model = new MultiLayerNetwork(builder.build());
         model.init();
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         model.setListeners(Collections.singletonList((IterationListener) new ScoreIterationListener(listenerFreq)));
 
         while(lfw.hasNext()) {
@@ -147,7 +147,7 @@ public class CNNLFWExample {
             model.fit(trainInput);
         }
 
-        log.info("Evaluate model....");
+        LOG.info("Evaluate model....");
         Evaluation eval = new Evaluation(lfw.getLabels());
         for(int i = 0; i < testInput.size(); i++) {
             INDArray output = model.output(testInput.get(i));
@@ -155,8 +155,8 @@ public class CNNLFWExample {
         }
         INDArray output = model.output(testInput.get(0));
         eval.eval(testLabels.get(0), output);
-        log.info(eval.stats());
-        log.info("****************Example finished********************");
+        LOG.info(eval.stats());
+        LOG.info("****************Example finished********************");
 
     }
 

--- a/src/main/java/org/deeplearning4j/examples/convolution/CNNMnistExample.java
+++ b/src/main/java/org/deeplearning4j/examples/convolution/CNNMnistExample.java
@@ -32,7 +32,7 @@ import java.util.*;
  */
 public class CNNMnistExample {
 
-    private static final Logger log = LoggerFactory.getLogger(CNNMnistExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CNNMnistExample.class);
 
     public static void main(String[] args) throws Exception {
         int numRows = 28;
@@ -51,10 +51,10 @@ public class CNNMnistExample {
         List<INDArray> testInput = new ArrayList<>();
         List<INDArray> testLabels = new ArrayList<>();
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator mnistIter = new MnistDataSetIterator(batchSize,numSamples, true);
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration.Builder builder = new NeuralNetConfiguration.Builder()
                 .seed(seed)
                 .iterations(iterations)
@@ -84,7 +84,7 @@ public class CNNMnistExample {
         MultiLayerNetwork model = new MultiLayerNetwork(conf);
         model.init();
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         model.setListeners(Arrays.asList((IterationListener) new ScoreIterationListener(listenerFreq)));
         while(mnistIter.hasNext()) {
             mnist = mnistIter.next();
@@ -95,9 +95,9 @@ public class CNNMnistExample {
             model.fit(trainInput);
         }
 
-        log.info("Evaluate weights....");
+        LOG.info("Evaluate weights....");
 
-        log.info("Evaluate model....");
+        LOG.info("Evaluate model....");
         Evaluation eval = new Evaluation(outputNum);
         for(int i = 0; i < testInput.size(); i++) {
             INDArray output = model.output(testInput.get(i));
@@ -105,8 +105,8 @@ public class CNNMnistExample {
         }
         INDArray output = model.output(testInput.get(0));
         eval.eval(testLabels.get(0), output);
-        log.info(eval.stats());
-        log.info("****************Example finished********************");
+        LOG.info(eval.stats());
+        LOG.info("****************Example finished********************");
 
 
     }

--- a/src/main/java/org/deeplearning4j/examples/convolution/LenetMnistExample.java
+++ b/src/main/java/org/deeplearning4j/examples/convolution/LenetMnistExample.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * Created by agibsonccc on 9/16/15.
  */
 public class LenetMnistExample {
-    private static final Logger log = LoggerFactory.getLogger(LenetMnistExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LenetMnistExample.class);
 
     public static void main(String[] args) throws Exception {
         int nChannels = 1;
@@ -35,11 +35,11 @@ public class LenetMnistExample {
         int iterations = 1;
         int seed = 123;
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator mnistTrain = new MnistDataSetIterator(batchSize,true,12345);
         DataSetIterator mnistTest = new MnistDataSetIterator(batchSize,false,12345);
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration.Builder builder = new NeuralNetConfiguration.Builder()
                 .seed(seed)
                 .iterations(iterations)
@@ -73,22 +73,22 @@ public class LenetMnistExample {
         model.init();
 
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         model.setListeners(new ScoreIterationListener(1));
         for( int i=0; i<nEpochs; i++ ) {
             model.fit(mnistTrain);
-            log.info("*** Completed epoch {} ***", i);
+            LOG.info("*** Completed epoch {} ***", i);
 
-            log.info("Evaluate model....");
+            LOG.info("Evaluate model....");
             Evaluation eval = new Evaluation(outputNum);
             while(mnistTest.hasNext()){
                 DataSet ds = mnistTest.next();
                 INDArray output = model.output(ds.getFeatureMatrix());
                 eval.eval(ds.getLabels(), output);
             }
-            log.info(eval.stats());
+            LOG.info(eval.stats());
             mnistTest.reset();
         }
-        log.info("****************Example finished********************");
+        LOG.info("****************Example finished********************");
     }
 }

--- a/src/main/java/org/deeplearning4j/examples/csv/CSVExample.java
+++ b/src/main/java/org/deeplearning4j/examples/csv/CSVExample.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
  */
 public class CSVExample {
 
-    private static Logger log = LoggerFactory.getLogger(CSVExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CSVExample.class);
 
     public static void main(String[] args) throws  Exception {
         RecordReader recordReader = new CSVRecordReader(0,",");
@@ -52,7 +52,7 @@ public class CSVExample {
         int listenerFreq = iterations;
 
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .seed(seed)
                 .iterations(iterations)
@@ -92,7 +92,7 @@ public class CSVExample {
         DataSet test = testAndTrain.getTest();
         INDArray output = model.output(test.getFeatureMatrix());
         eval.eval(test.getLabels(), output);
-        log.info(eval.stats());
+        LOG.info(eval.stats());
 
     }
 

--- a/src/main/java/org/deeplearning4j/examples/deepbelief/DBNIrisExample.java
+++ b/src/main/java/org/deeplearning4j/examples/deepbelief/DBNIrisExample.java
@@ -38,7 +38,7 @@ import java.util.Random;
  */
 public class DBNIrisExample {
 
-    private static Logger log = LoggerFactory.getLogger(DBNIrisExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DBNIrisExample.class);
 
     public static void main(String[] args) throws Exception {
         // Customizing params
@@ -55,19 +55,19 @@ public class DBNIrisExample {
         int seed = 123;
         int listenerFreq = 1;
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator iter = new IrisDataSetIterator(batchSize, numSamples);
         DataSet next = iter.next();
         next.shuffle();
         next.normalizeZeroMeanZeroUnitVariance();
 
-        log.info("Split data....");
+        LOG.info("Split data....");
         SplitTestAndTrain testAndTrain = next.splitTestAndTrain(splitTrainNum, new Random(seed));
         DataSet train = testAndTrain.getTrain();
         DataSet test = testAndTrain.getTest();
         Nd4j.ENFORCE_NUMERICAL_STABILITY = true;
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .seed(seed) // Locks in weight initialization for tuning
                 .iterations(iterations) // # training iterations predict/classify & backprop
@@ -98,21 +98,21 @@ public class DBNIrisExample {
         model.init();
 
         model.setListeners(new ScoreIterationListener(listenerFreq));
-        log.info("Train model....");
+        LOG.info("Train model....");
         model.fit(train);
 
-        log.info("Evaluate weights....");
+        LOG.info("Evaluate weights....");
         for(org.deeplearning4j.nn.api.Layer layer : model.getLayers()) {
             INDArray w = layer.getParam(DefaultParamInitializer.WEIGHT_KEY);
-            log.info("Weights: " + w);
+            LOG.info("Weights: " + w);
         }
 
-        log.info("Evaluate model....");
+        LOG.info("Evaluate model....");
         Evaluation eval = new Evaluation(outputNum);
         eval.eval(test.getLabels(), model.output(test.getFeatureMatrix(), Layer.TrainingMode.TEST));
-        log.info(eval.stats());
+        LOG.info(eval.stats());
 
-        log.info("****************Example finished********************");
+        LOG.info("****************Example finished********************");
 
 
         OutputStream fos = Files.newOutputStream(Paths.get("coefficients.bin"));

--- a/src/main/java/org/deeplearning4j/examples/deepbelief/DBNMnistFullExample.java
+++ b/src/main/java/org/deeplearning4j/examples/deepbelief/DBNMnistFullExample.java
@@ -26,7 +26,7 @@ import java.util.Collections;
  */
 public class DBNMnistFullExample {
 
-    private static Logger log = LoggerFactory.getLogger(DBNMnistFullExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DBNMnistFullExample.class);
 
     public static void main(String[] args) throws Exception {
         final int numRows = 28;
@@ -38,10 +38,10 @@ public class DBNMnistFullExample {
         int seed = 123;
         int listenerFreq = batchSize / 5;
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator iter = new MnistDataSetIterator(batchSize,numSamples,true);
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
            .seed(seed)
            .gradientNormalization(GradientNormalization.ClipElementWiseAbsoluteValue)
@@ -75,10 +75,10 @@ public class DBNMnistFullExample {
         model.init();
         model.setListeners(Collections.singletonList((IterationListener) new ScoreIterationListener(listenerFreq)));
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         model.fit(iter); // achieves end to end pre-training
 
-        log.info("Evaluate model....");
+        LOG.info("Evaluate model....");
         Evaluation eval = new Evaluation(outputNum);
 
         DataSetIterator testIter = new MnistDataSetIterator(100,10000);
@@ -88,8 +88,8 @@ public class DBNMnistFullExample {
             eval.eval(testMnist.getLabels(), predict2);
         }
 
-        log.info(eval.stats());
-        log.info("****************Example finished********************");
+        LOG.info(eval.stats());
+        LOG.info("****************Example finished********************");
 
     }
 

--- a/src/main/java/org/deeplearning4j/examples/deepbelief/DeepAutoEncoderExample.java
+++ b/src/main/java/org/deeplearning4j/examples/deepbelief/DeepAutoEncoderExample.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
  */
 public class DeepAutoEncoderExample {
 
-    private static Logger log = LoggerFactory.getLogger(DeepAutoEncoderExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DeepAutoEncoderExample.class);
 
     public static void main(String[] args) throws Exception {
         final int numRows = 28;
@@ -34,10 +34,10 @@ public class DeepAutoEncoderExample {
         int iterations = 1;
         int listenerFreq = iterations/5;
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator iter = new MnistDataSetIterator(batchSize,numSamples,true);
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .seed(seed)
                 .iterations(iterations)
@@ -61,7 +61,7 @@ public class DeepAutoEncoderExample {
 
         model.setListeners(Arrays.asList((IterationListener) new ScoreIterationListener(listenerFreq)));
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         while(iter.hasNext()) {
             DataSet next = iter.next();
             model.fit(new DataSet(next.getFeatureMatrix(),next.getFeatureMatrix()));

--- a/src/main/java/org/deeplearning4j/examples/glove/GloVeExample.java
+++ b/src/main/java/org/deeplearning4j/examples/glove/GloVeExample.java
@@ -19,7 +19,7 @@ import java.util.Collection;
  */
 public class GloVeExample {
 
-    private static final Logger log = LoggerFactory.getLogger(GloVeExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(GloVeExample.class);
 
     public static void main(String[] args) throws Exception {
         File inputFile = new ClassPathResource("raw_sentences.txt").getFile();
@@ -58,10 +58,10 @@ public class GloVeExample {
         glove.fit();
 
         double simD = glove.similarity("day", "night");
-        log.info("Day/night similarity: " + simD);
+        LOG.info("Day/night similarity: " + simD);
 
         Collection<String> words = glove.wordsNearest("day", 10);
-        log.info("Nearest words to 'day': " + words);
+        LOG.info("Nearest words to 'day': " + words);
 
         System.exit(0);
     }

--- a/src/main/java/org/deeplearning4j/examples/mlp/MLPMnistCMGSExample.java
+++ b/src/main/java/org/deeplearning4j/examples/mlp/MLPMnistCMGSExample.java
@@ -27,7 +27,7 @@ import java.util.Random;
  */
 public class MLPMnistCMGSExample {
 
-    private static Logger log = LoggerFactory.getLogger(MLPMnistCMGSExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MLPMnistCMGSExample.class);
 
 
     public static void main(String[] args) throws Exception {
@@ -48,15 +48,15 @@ public class MLPMnistCMGSExample {
         List<INDArray> testLabels = new ArrayList<>();
 
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator iter = new MnistDataSetIterator(batchSize,numSamples);
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerNetwork model = new CMGSNet(numRows, numColumns, outputNum, seed, iterations).init();
 
         model.setListeners(Arrays.asList((IterationListener) new ScoreIterationListener(listenerFreq)));
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         while(iter.hasNext()) {
             mnist = iter.next();
             trainTest = mnist.splitTestAndTrain(splitTrainNum, new Random(seed)); // train set that is the result
@@ -66,7 +66,7 @@ public class MLPMnistCMGSExample {
             model.fit(trainInput);
         }
 
-        log.info("Evaluate model....");
+        LOG.info("Evaluate model....");
         Evaluation eval = new Evaluation(outputNum);
         for(int i = 0; i < testInput.size(); i++) {
             INDArray output = model.output(testInput.get(i));
@@ -74,8 +74,8 @@ public class MLPMnistCMGSExample {
         }
 
 
-        log.info(eval.stats());
-        log.info("****************Example finished********************");
+        LOG.info(eval.stats());
+        LOG.info("****************Example finished********************");
 
     }
 

--- a/src/main/java/org/deeplearning4j/examples/mlp/MLPMnistSingleLayerExample.java
+++ b/src/main/java/org/deeplearning4j/examples/mlp/MLPMnistSingleLayerExample.java
@@ -32,7 +32,7 @@ import java.util.*;
  */
 public class MLPMnistSingleLayerExample {
 
-    private static Logger log = LoggerFactory.getLogger(MLPMnistSingleLayerExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MLPMnistSingleLayerExample.class);
 
     public static void main(String[] args) throws Exception {
         Nd4j.ENFORCE_NUMERICAL_STABILITY = true;
@@ -51,10 +51,10 @@ public class MLPMnistSingleLayerExample {
         List<INDArray> testInput = new ArrayList<>();
         List<INDArray> testLabels = new ArrayList<>();
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator mnistIter = new MnistDataSetIterator(batchSize, numSamples,true);
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .seed(seed)
                 .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
@@ -83,7 +83,7 @@ public class MLPMnistSingleLayerExample {
         model.init();
         model.setListeners(Arrays.asList((IterationListener) new ScoreIterationListener(listenerFreq)));
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         model.setListeners(Arrays.asList((IterationListener) new ScoreIterationListener(listenerFreq)));
         while(mnistIter.hasNext()) {
             mnist = mnistIter.next();
@@ -94,15 +94,15 @@ public class MLPMnistSingleLayerExample {
             model.fit(trainInput);
         }
 
-        log.info("Evaluate model....");
+        LOG.info("Evaluate model....");
         Evaluation eval = new Evaluation(outputNum);
         for(int i = 0; i < testInput.size(); i++) {
             INDArray output = model.output(testInput.get(i));
             eval.eval(testLabels.get(i), output);
         }
 
-        log.info(eval.stats());
-        log.info("****************Example finished********************");
+        LOG.info(eval.stats());
+        LOG.info("****************Example finished********************");
 
     }
 

--- a/src/main/java/org/deeplearning4j/examples/multinetwork/DBNMnistFullExample.java
+++ b/src/main/java/org/deeplearning4j/examples/multinetwork/DBNMnistFullExample.java
@@ -27,7 +27,7 @@ import java.util.Collections;
  */
 public class DBNMnistFullExample {
 
-    private static Logger log = LoggerFactory.getLogger(DBNMnistFullExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DBNMnistFullExample.class);
 
     public static void main(String[] args) throws Exception {
         final int numRows = 28;
@@ -39,10 +39,10 @@ public class DBNMnistFullExample {
         int seed = 123;
         int listenerFreq = batchSize / 5;
 
-        log.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator iter = new MnistDataSetIterator(batchSize,numSamples,true);
         DataSet trainingSet = iter.next();
-        log.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .seed(seed)
                 .gradientNormalization(GradientNormalization.ClipElementWiseAbsoluteValue)
@@ -73,7 +73,7 @@ public class DBNMnistFullExample {
         model.init();
         model.setListeners(new ScoreIterationListener(listenerFreq));
 
-        log.info("Train model....");
+        LOG.info("Train model....");
         model.fit(trainingSet); // achieves end to end pre-training
 
 
@@ -102,7 +102,7 @@ public class DBNMnistFullExample {
         modelRegression.fit(trainingSet);
 
  
-        log.info("****************Example finished********************");
+        LOG.info("****************Example finished********************");
 
     }
 

--- a/src/main/java/org/deeplearning4j/examples/paragraphvectors/ParagraphVectorsClassifierExample.java
+++ b/src/main/java/org/deeplearning4j/examples/paragraphvectors/ParagraphVectorsClassifierExample.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class ParagraphVectorsClassifierExample {
 
-    private static final Logger log = LoggerFactory.getLogger(ParagraphVectorsClassifierExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ParagraphVectorsClassifierExample.class);
 
     public static void main(String[] args) throws Exception {
         ClassPathResource resource = new ClassPathResource("paravec/labeled");
@@ -90,9 +90,9 @@ public class ParagraphVectorsClassifierExample {
              please note, document.getLabel() is used just to show which document we're looking at now, as a substitute for printing out the whole document itself.
              So, labels on these two documents are used like titles, just to visualize our classification done properly
             */
-            log.info("Document '" + document.getLabel() + "' falls into the following categories: ");
+            LOG.info("Document '" + document.getLabel() + "' falls into the following categories: ");
             for (Pair<String, Double> score: scores) {
-                log.info("        " + score.getFirst() + ": " + score.getSecond());
+                LOG.info("        " + score.getFirst() + ": " + score.getSecond());
             }
 
             /*

--- a/src/main/java/org/deeplearning4j/examples/paragraphvectors/ParagraphVectorsTextExample.java
+++ b/src/main/java/org/deeplearning4j/examples/paragraphvectors/ParagraphVectorsTextExample.java
@@ -26,7 +26,7 @@ import java.io.File;
  */
 public class ParagraphVectorsTextExample {
 
-    private static final Logger log = LoggerFactory.getLogger(ParagraphVectorsTextExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ParagraphVectorsTextExample.class);
 
     public static void main(String[] args) throws Exception {
         ClassPathResource resource = new ClassPathResource("/raw_sentences.txt");
@@ -78,16 +78,16 @@ public class ParagraphVectorsTextExample {
          */
 
         double similarity1 = vec.similarity("DOC_9835", "DOC_12492");
-        log.info("9835/12492 similarity: " + similarity1);
+        LOG.info("9835/12492 similarity: " + similarity1);
 
         double similarity2 = vec.similarity("DOC_3720", "DOC_16392");
-        log.info("3720/16392 similarity: " + similarity2);
+        LOG.info("3720/16392 similarity: " + similarity2);
 
         double similarity3 = vec.similarity("DOC_6347", "DOC_3720");
-        log.info("6347/3720 similarity: " + similarity3);
+        LOG.info("6347/3720 similarity: " + similarity3);
 
         // likelihood in this case should be significantly lower
         double similarityX = vec.similarity("DOC_3720", "DOC_9852");
-        log.info("3720/9852 similarity: " + similarityX);
+        LOG.info("3720/9852 similarity: " + similarityX);
     }
 }

--- a/src/main/java/org/deeplearning4j/examples/sequencevectors/SequenceVectorsTextExample.java
+++ b/src/main/java/org/deeplearning4j/examples/sequencevectors/SequenceVectorsTextExample.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class SequenceVectorsTextExample {
 
-    protected static final Logger logger = LoggerFactory.getLogger(SequenceVectorsTextExample.class);
+    protected static final Logger LOG = LoggerFactory.getLogger(SequenceVectorsTextExample.class);
 
     public static void main(String[] args) throws Exception {
 
@@ -154,7 +154,7 @@ public class SequenceVectorsTextExample {
             objects/relations please take care of Labels uniqueness and meaning for yourself.
          */
         double sim = vectors.similarity("day", "night");
-        logger.info("Day/night similarity: " + sim);
+        LOG.info("Day/night similarity: " + sim);
 
     }
 }

--- a/src/main/java/org/deeplearning4j/examples/test/Test.java
+++ b/src/main/java/org/deeplearning4j/examples/test/Test.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * Created by agibsonccc on 9/16/15.
  */
 public class Test {
-    private static Logger LOGGER = LoggerFactory.getLogger(Test.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Test.class);
 
     public static void main(String[] args) {
         final int numRows = 4;
@@ -40,18 +40,18 @@ public class Test {
         int seed = 123;
         int listenerFreq = iterations/5;
         Nd4j.getRandom().setSeed(seed);
-        LOGGER.info("Load data....");
+        LOG.info("Load data....");
         DataSetIterator iter = new IrisDataSetIterator(batchSize, numSamples);
         DataSet iris = iter.next();
         iris.normalizeZeroMeanZeroUnitVariance();
 
-        LOGGER.info("Split data....");
+        LOG.info("Split data....");
         SplitTestAndTrain testAndTrain = iris.splitTestAndTrain(splitTrainNum, new Random(seed));
         DataSet train = testAndTrain.getTrain();
         Nd4j.ENFORCE_NUMERICAL_STABILITY = true;
 
         MultiLayerNetwork model;
-        LOGGER.info("Build model....");
+        LOG.info("Build model....");
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
                 .seed(seed) // Seed to lock in weight initialization for tuning
                 .iterations(iterations) // # training iterations predict/classify & backprop
@@ -82,7 +82,7 @@ public class Test {
         model.init();
         model.setListeners(Collections.singletonList((IterationListener) new ScoreIterationListener(listenerFreq)));
 
-        LOGGER.info("Train model....");
+        LOG.info("Train model....");
         model.fit(train);
 
 //        for(int i=0; i<10; i++){

--- a/src/main/java/org/deeplearning4j/examples/tsne/TSNEStandardExample.java
+++ b/src/main/java/org/deeplearning4j/examples/tsne/TSNEStandardExample.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public class TSNEStandardExample {
 
-    private static Logger log = LoggerFactory.getLogger(TSNEStandardExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TSNEStandardExample.class);
 
     public static void main(String[] args) throws Exception  {
         int iterations = 100;
@@ -32,7 +32,7 @@ public class TSNEStandardExample {
         Nd4j.factory().setDType(DataBuffer.Type.DOUBLE);
         List<String> cacheList = new ArrayList<>();
 
-        log.info("Load & Vectorize data....");
+        LOG.info("Load & Vectorize data....");
         File wordFile = new ClassPathResource("words.txt").getFile();
         Pair<InMemoryLookupTable,VocabCache> vectors = WordVectorSerializer.loadTxt(wordFile);
         VocabCache cache = vectors.getSecond();
@@ -41,7 +41,7 @@ public class TSNEStandardExample {
         for(int i = 0; i < cache.numWords(); i++)
             cacheList.add(cache.wordAtIndex(i));
 
-        log.info("Build model....");
+        LOG.info("Build model....");
         BarnesHutTsne tsne = new BarnesHutTsne.Builder()
                 .setMaxIter(iterations).theta(0.5)
                 .normalize(false)
@@ -50,7 +50,7 @@ public class TSNEStandardExample {
                 .usePca(false)
                 .build();
 
-        log.info("Store TSNE Coordinates for Plotting....");
+        LOG.info("Store TSNE Coordinates for Plotting....");
         String outputFile = "target/archive-tmp/tsne-standard-coords.csv";
         (new File(outputFile)).getParentFile().mkdirs();
         tsne.plot(weights,2,cacheList,outputFile);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar
rule squid:S1312 Loggers should be "private static final" and should share a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1312
Please let me know if you have any questions.
George Kankava