### PR TITLE
Adding EditorConfig for providing some codestyle-basics.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
dl4j-examples lacks in my opinion a bit of a common codestyle. This EditorConfig-configuration defines at least some common basics such as UTF8-encoding, indentation style etc. 

[EditorConfig](http://editorconfig.org/) is supposed to define common configurations across different IDEs, editors etc.. GitHub and IntelliJ support EditorConfig by default, for example.