### PR TITLE
changing lenet cnn example to use testmode when scoring test data

### DIFF
--- a/src/main/java/org/deeplearning4j/examples/convolution/LenetMnistExample.java
+++ b/src/main/java/org/deeplearning4j/examples/convolution/LenetMnistExample.java
@@ -95,7 +95,7 @@ public class LenetMnistExample {
             Evaluation eval = new Evaluation(outputNum);
             while(mnistTest.hasNext()){
                 DataSet ds = mnistTest.next();
-                INDArray output = model.output(ds.getFeatureMatrix());
+                INDArray output = model.output(ds.getFeatureMatrix(), false);
                 eval.eval(ds.getLabels(), output);
             }
             log.info(eval.stats());


### PR DESCRIPTION

I simply added and set the Boolean parameter for `model.output()` to **false** which invokes "test mode" for scoring rather than the default (**true**).  I'm not sure if it makes a difference for models without dropout, but with dropout, it certainly does.

There's no dropout in this example, however there is in the Scala clone [here](https://github.com/kogecoo/dl4j-0.4-examples-scala/blob/master/src/main/scala/org/deeplearning4j/examples/convolution/LenetMnistExample.scala), which initially threw me off.
