### PR TITLE
Par2vec text fix

### DIFF
--- a/src/main/java/org/deeplearning4j/examples/nlp/paragraphvectors/ParagraphVectorsTextExample.java
+++ b/src/main/java/org/deeplearning4j/examples/nlp/paragraphvectors/ParagraphVectorsTextExample.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.examples.nlp.paragraphvectors;
 
+import org.canova.api.util.ClassPathResource;
 import org.deeplearning4j.models.paragraphvectors.ParagraphVectors;
 import org.deeplearning4j.models.word2vec.wordstore.inmemory.InMemoryLookupCache;
 import org.deeplearning4j.text.sentenceiterator.SentenceIterator;
@@ -10,7 +11,6 @@ import org.deeplearning4j.text.sentenceiterator.BasicLineIterator;
 import org.deeplearning4j.text.documentiterator.LabelsSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.ClassPathResource;
 
 import java.io.File;
 

--- a/src/main/java/org/deeplearning4j/examples/nlp/paragraphvectors/ParagraphVectorsTextExample.java
+++ b/src/main/java/org/deeplearning4j/examples/nlp/paragraphvectors/ParagraphVectorsTextExample.java
@@ -48,7 +48,7 @@ public class ParagraphVectorsTextExample {
 
         ParagraphVectors vec = new ParagraphVectors.Builder()
                 .minWordFrequency(1)
-                .iterations(3)
+                .iterations(5)
                 .epochs(1)
                 .layerSize(100)
                 .learningRate(0.025)
@@ -75,19 +75,22 @@ public class ParagraphVectorsTextExample {
 
             this is special sentence, that has nothing common with previous sentences
             line 9853: We now have one .
+
+            Note that docs are indexed from 0
          */
 
         double similarity1 = vec.similarity("DOC_9835", "DOC_12492");
-        log.info("9835/12492 similarity: " + similarity1);
+        log.info("9836/12493 ('This is my house .'/'This is my world .') similarity: " + similarity1);
 
         double similarity2 = vec.similarity("DOC_3720", "DOC_16392");
-        log.info("3720/16392 similarity: " + similarity2);
+        log.info("3721/16393 ('This is my way .'/'This is my work .') similarity: " + similarity2);
 
         double similarity3 = vec.similarity("DOC_6347", "DOC_3720");
-        log.info("6347/3720 similarity: " + similarity3);
+        log.info("6348/3721 ('This is my case .'/'This is my way .') similarity: " + similarity3);
 
         // likelihood in this case should be significantly lower
         double similarityX = vec.similarity("DOC_3720", "DOC_9852");
-        log.info("3720/9852 similarity: " + similarityX);
+        log.info("3721/9853 ('This is my way .'/'We now have one .') similarity: " + similarityX +
+            "(should be significantly lower)");
     }
 }


### PR DESCRIPTION
First, I fixed iterations count so that the difference between the last pair and all previous becomes significant (see [here](https://gist.github.com/astrakhantsev/639742481981fe08c0fcc9636b8e364a) for examples of output for iterCount=3). Now the difference is more than 0.1. Also a little more explanation was added. 

Second, I tried to fix the bug with trying to instantiate File from jar entry (see [output](https://gist.github.com/astrakhantsev/cdb29a08e774b0f7b33db77ec5b2c5c7) and relevant [Stackoverflow question](http://stackoverflow.com/questions/14876836/file-inside-jar-is-not-visible-for-spring)). 
I tried to replace resource.getFile() by resource.getInputStream(), but then it fails, because BasicLineIterator tries to read the file twice, and in case of InputStream, it tries to reset() stream (see line 73).
So, better solution would be to fix BasicLineIterator, but for now I created workaround so that the user can actually run this example (anyway, the only option to launch examples now is to clone the repo).